### PR TITLE
Automatically build macOS and Linux wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: python
+dist: trusty
+sudo: false
+cache:
+  directories:
+  - $HOME/Library/Caches/Homebrew
+env:
+  global:
+    - MUPDF='https://mupdf.com/downloads/mupdf-1.12.0-source.tar.gz'
+    - COPYFILE_DISABLE=1  # for macos tar errors
+    - TWINE_USERNAME=pymupdf
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      python: "3.6"
+      services:
+        - docker
+      env: PIP=pip
+      before_script:
+        - export CIBW_BEFORE_BUILD="yum install -y zlib-devel && cd mupdf && make HAVE_X11=no HAVE_GLFW=no HAVE_GLUT=no prefix=/usr/local install && cd .."
+        - export CIBW_ENVIRONMENT='CFLAGS="-fPIC -std=gnu99"'
+
+    - os: osx
+      osx_image: xcode8.3
+      language: generic   # osx + "language: python" is broken; use generic
+      services: 
+        - docker
+      env: PIP=pip3
+      before_install:
+        - brew update -q
+        - brew outdated python || brew upgrade python  # get py3
+        - sudo mkdir -p /usr/local/man && sudo chmod a+rw /usr/local/man  # make pip install error go away
+      before_script:
+        - export CIBW_BEFORE_BUILD="cd mupdf && make HAVE_X11=no HAVE_GLFW=no HAVE_GLUT=no prefix=/usr/local install && cd .."
+        - export CIBW_ENVIRONMENT='CFLAGS=-fPIC'
+
+install:
+  - $PIP install cibuildwheel==0.7.0 twine
+  - mkdir mupdf && wget -q $MUPDF -O - | tar zx -C mupdf --strip-components=1
+
+script:
+  - export CIBW_ENVIRONMENT='CFLAGS="-fPIC -std=gnu99"'
+  - export CIBW_SKIP="cp33-* *i686"  # Skip Python 3.3 and i686 (<1% of users now)
+  - cibuildwheel --output-dir wheelhouse
+  - |
+    if [[ "$TRAVIS_TAG" != "" ]]; then
+      python3 -m twine upload wheelhouse/*.whl
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
 script:
   - export CIBW_ENVIRONMENT='CFLAGS="-fPIC -std=gnu99"'
   - export CIBW_SKIP="cp33-* *i686"  # Skip Python 3.3 and i686 (<1% of users now)
+  - export CIBW_TEST_COMMAND="python -c 'import fitz'"
   - cibuildwheel --output-dir wheelhouse
   - |
     if [[ "$TRAVIS_TAG" != "" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ if sys.platform.startswith('linux'):
                        #library_dirs=['<mupdf_and_3rd_party_libraries_dir>'],
                        libraries=[
                            'mupdf',
-                           'crypto', #openssl is required by mupdf on archlinux
-                           'jbig2dec', 'openjp2', 'jpeg', 'freetype',
                            'mupdfthird',
+                           # 'jbig2dec', 'openjp2', 'jpeg', 'freetype',
+                           # 'crypto', #openssl is required by mupdf on archlinux
                            ], # the libraries to link with
                       )
 elif sys.platform.startswith('darwin'):


### PR DESCRIPTION
To get this to work you will need to:
* sign up for Travis CI and link your Github account
* create a PyPI user with upload permission (or give Travis your password)
* set ``TWINE_USERNAME`` to the user that should upload to PyPI
* in Travis configuration, set ``TWINE_PASSWORD`` to your password

Then it should automatically build every release and automatically upload any tagged release. You can force rebuilds in Travis. If the release is not tagged it will generate wheels but not upload them.

If PyMuPDF acquires a test suite then ``CIBW_TEST_COMMAND`` could be changed to run the test suite. Currently it just attempts to ``import fitz`` after building and installing the wheel.

Appveyor is a Windowsy equivalent to Travis that could automate your procedure on that end.